### PR TITLE
Update code for newer versions of python & packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ already been implemented.
 Dependencies:
 -------------
 
-Python packages required: Anaconda 2019/3, matplotlib 3.0 & its required
-dependencies, python 3.7.3,  h5py. Will not work with older versions of anaconda3 and
+Python packages required: Anaconda 2021/5, matplotlib 3.0 & its required
+dependencies, python 3.7.3,  h5py, scipy >=v1.6.0. Will not work with older versions of anaconda3 and
 matplotlib 2.0 or older.
 
 To use the movie saving feature: ffmpeg & xterm.
 
 Iseult should work on Windows, MacOS & Linux.
 
-To run Iseult on tigressdata type the following:
+To run Iseult on tigressdata or stellar vis nodes type the following:
 ```bash
-$ module load anaconda3/2019.3
+$ module load anaconda3/2021.5
 $ cd /path/to/Iseult/
 $ chmod +x ./iseult.py
 $ ./iseult.py

--- a/src/fields_panel.py
+++ b/src/fields_panel.py
@@ -229,7 +229,7 @@ class FieldsPanel:
                     """
                     messagebox.showinfo('Error when evaluating user defined function 1:', print(sys.exc_info()))#(err_msg)
 
-                    self.fx = np.NAN
+                    self.fx = np.nan
                     self.flagx = 0
 
             if self.GetPlotParam('show_y'):
@@ -259,7 +259,7 @@ class FieldsPanel:
 
                         """
                     messagebox.showinfo('Error when evaluating user defined function 2:', print(sys.exc_info()))#(err_msg)
-                    self.fy = np.NAN
+                    self.fy = np.nan
                     self.flagy = 0
 
             if self.GetPlotParam('show_z'):
@@ -291,7 +291,7 @@ class FieldsPanel:
                     """
                     messagebox.showinfo('Error when evaluating user defined function 3:', print(sys.exc_info()))#(err_msg)
 
-                    self.fz = np.NAN
+                    self.fz = np.nan
                     self.flagz = 0
 
     def draw(self,):

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -41,14 +41,14 @@ class FieldsPanel:
                        'cmdstr3': example,
                        'OneDOnly': [False, False, False],
                        'yaxis_label': ['$B$','$E$','$J$','$B$'],
-                       '2D_label': [['$B_x$','$B_y$','$B_z$'],
-                                    ['$E_x$','$E_y$','$E_z$'],
-                                    ['$J_x$','$J_y$','$J_z$'],
-                                    ['$B_\mathrm{tot}$','$B_\mathrm{tot}$','$B_\mathrm{tot}$']],
-                       '1D_label': [['$B_x$','$B_y$','$B_z$'],
-                                    ['$E_x$','$E_y$','$E_z$'],
-                                    ['$J_x$','$J_y$','$J_z$'],
-                                    ['$B_\mathrm{tot}$','$B_\mathrm{tot}$','$B_\mathrm{tot}$']],
+                       '2D_label': [[r'$B_x$',r'$B_y$',r'$B_z$'],
+                                    [r'$E_x$',r'$E_y$',r'$E_z$'],
+                                    [r'$J_x$',r'$J_y$',r'$J_z$'],
+                                    [r'$B_\mathrm{tot}$',r'$B_\mathrm{tot}$',r'$B_\mathrm{tot}$']],
+                       '1D_label': [[r'$B_x$',r'$B_y$',r'$B_z$'],
+                                    [r'$E_x$',r'$E_y$',r'$E_z$'],
+                                    [r'$J_x$',r'$J_y$',r'$J_z$'],
+                                    [r'$B_\mathrm{tot}$',r'$B_\mathrm{tot}$',r'$B_\mathrm{tot}$']],
                        'show_x' : 1,
                        'show_y' : 1,
                        'show_z' : 1,
@@ -287,7 +287,7 @@ class FieldsPanel:
                         """
                         messagebox.showinfo('Error when evaluating user defined function 1:', print(sys.exc_info()))#(err_msg)
 
-                        self.fx = np.NAN
+                        self.fx = np.nan
                         self.flagx = 0
 
             if self.GetPlotParam('show_y'):
@@ -329,7 +329,7 @@ class FieldsPanel:
 
                         """
                         messagebox.showinfo('Error when evaluating user defined function 2:', print(sys.exc_info()))#(err_msg)
-                        self.fy = np.NAN
+                        self.fy = np.nan
                         self.flagy = 0
 
             if self.GetPlotParam('show_z'):
@@ -373,7 +373,7 @@ class FieldsPanel:
                         """
                         messagebox.showinfo('Error when evaluating user defined function 3:', print(sys.exc_info()))#(err_msg)
 
-                        self.fz = np.NAN
+                        self.fz = np.nan
                         self.flagz = 0
 
     def draw(self):

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2577,7 +2577,7 @@ class MainApp(Tk.Tk):
                                     elif elm == 'c':
                                         self.DataDict[elm]= 0.45
                                     elif elm == 'ppc0':
-                                        self.DataDict[elm] = np.NaN
+                                        self.DataDict[elm] = np.nan
                                     elif elm == 'my':
                                         tmpSize = ((self.MaxYInd+1)*f['istep'][0])//(f['my0'][0]-5)
                                         self.DataDict[elm] = np.ones(tmpSize)*(f['my0'][0])
@@ -2623,7 +2623,7 @@ class MainApp(Tk.Tk):
                                     elif elm == 'c':
                                         self.DataDict[elm]= 0.45
                                     elif elm == 'ppc0':
-                                        self.DataDict[elm] = np.NaN
+                                        self.DataDict[elm] = np.nan
                                     elif elm == 'my':
                                         tmpSize = ((self.MaxYInd+1)*f['istep'][0])//(f['my0'][0]-5)
                                         self.DataDict[elm] = np.ones(tmpSize)*(f['my0'][0])
@@ -3158,7 +3158,7 @@ class MainApp(Tk.Tk):
 
         if self.MainParamDict['ShowTitle']:
             tmpstr = self.PathDict['Prtl'][self.TimeStep.value-1].split('.')[-1]
-            self.f.suptitle(os.path.abspath(self.dirname)+ '/*.'+tmpstr+' at time t = %d $\omega_{pe}^{-1}$'  % round(self.DataDict['time'][0]), size = 15)
+            self.f.suptitle(os.path.abspath(self.dirname)+ '/*.'+tmpstr+r' at time t = %d $\omega_{pe}^{-1}$'  % round(self.DataDict['time'][0]), size = 15)
         if keep_view:
             self.LoadView()
 
@@ -3259,7 +3259,7 @@ class MainApp(Tk.Tk):
 
         if self.MainParamDict['ShowTitle']:
             tmpstr = self.PathDict['Prtl'][self.TimeStep.value-1].split('.')[-1]
-            self.f.suptitle(os.path.abspath(self.dirname)+ '/*.'+tmpstr+' at time t = %d $\omega_{pe}^{-1}$'  % round(self.DataDict['time'][0]), size = 15)
+            self.f.suptitle(os.path.abspath(self.dirname)+ '/*.'+tmpstr+r' at time t = %d $\omega_{pe}^{-1}$'  % round(self.DataDict['time'][0]), size = 15)
 
         if keep_view:
             self.LoadView()
@@ -3471,11 +3471,11 @@ class MainApp(Tk.Tk):
                     '''
                     # Normalize by b0
                 if np.abs(f['sigma'][0])==0:
-                    self.btheta = np.NaN
+                    self.btheta = np.nan
                 else:
                     self.btheta = f['btheta'][0]
             except KeyError:
-                self.btheta = np.NaN
+                self.btheta = np.nan
 
 
         with h5py.File(os.path.join(self.dirname,self.PathDict['Flds'][0]), 'r') as f:
@@ -3522,7 +3522,7 @@ class MainApp(Tk.Tk):
         ishock_final = np.where(dens_arr[dens_arr.shape[0]//2,jstart:]>=dens_half_max)[0][-1]
         xshock_final = xaxis_final[ishock_final]
         self.shock_speed = xshock_final/final_time
-        self.prev_shock_loc = np.NaN
+        self.prev_shock_loc = np.nan
 
     def setKnob(self, value):
         # If the time parameter changes update the plots

--- a/src/spectra.py
+++ b/src/spectra.py
@@ -10,7 +10,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
 from scipy.special import kn # Modified Bessel function
 from scipy.stats import linregress
-from scipy.integrate import simps, cumtrapz
+from scipy.integrate import cumulative_trapezoid
 class SpectralPanel:
     # A dictionary of all of the parameters for this plot with the default parameters
 
@@ -618,7 +618,7 @@ class SpectralPanel:
             endSumF = np.cumsum(dF[::-1])[::-1]
             '''
             # Do a reverse cummulative trapz integration over the energy_dist
-            endSum = cumtrapz(energy_dist[::-1],self.gamma[::-1])[::-1]
+            endSum =  cumulative_trapezoid(energy_dist[::-1],self.gamma[::-1])[::-1]
             endSum *= -1
 
             logF = np.nan

--- a/src/spectra_panel.py
+++ b/src/spectra_panel.py
@@ -9,7 +9,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
 from scipy.special import kn # Modified Bessel function
 from scipy.stats import linregress
-from scipy.integrate import simps, cumtrapz
+from scipy.integrate import cumulative_trapezoid
 class SpectralPanel:
     # A dictionary of all of the parameters for this plot with the default parameters
 
@@ -563,7 +563,7 @@ class SpectralPanel:
             endSumF = np.cumsum(dF[::-1])[::-1]
             '''
             # Do a reverse cummulative trapz integration over the energy_dist
-            endSum = cumtrapz(energy_dist[::-1],self.gamma[::-1])[::-1]
+            endSum =  cumulative_trapezoid(energy_dist[::-1],self.gamma[::-1])[::-1]
             endSum *= -1
 
             logF = np.nan


### PR DESCRIPTION
- (Breaking Change) replace calls to `scipy.integrate.cumtrapz` with the current name `scipy.integrate.cumulative_trapezoid`. Now requires at least scipy v1.6.0. On Stellar this means using at the anaconda3/2021.5 module or newer or setting up your own python environment.
- Update readme.md to the new version of anaconda required on Stellar
- Remove import of deprecated `scipy.integrate.simps` function that wasn't used
- Replace deprecated `np.NaN` with `np.nan`
- Make some strings raw strings to avoid treating the backslash as an escape character in some strings that are LaTeX code

Note that without the breaking name change Iseult is not compatible with scipy v1.14.0 or greater.